### PR TITLE
Fix python interpreter path

### DIFF
--- a/audio-analyzer-frontend/src/app/api/model/route.ts
+++ b/audio-analyzer-frontend/src/app/api/model/route.ts
@@ -98,13 +98,11 @@ if __name__ == "__main__":
     print(json.dumps(result))
 `;
 
-    const python = spawn('/workspace/venv/bin/python', ['-c', pythonScript, model], {
+    const python = spawn('/usr/bin/python3', ['-c', pythonScript, model], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: '/workspace',
       env: {
-        ...process.env,
-        PATH: '/workspace/venv/bin:' + process.env.PATH,
-        VIRTUAL_ENV: '/workspace/venv'
+        ...process.env
       }
     });
 
@@ -185,13 +183,11 @@ if __name__ == "__main__":
     print(json.dumps(result))
 `;
 
-    const python = spawn('/workspace/venv/bin/python', ['-c', pythonScript, model], {
+    const python = spawn('/usr/bin/python3', ['-c', pythonScript, model], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: '/workspace',
       env: {
-        ...process.env,
-        PATH: '/workspace/venv/bin:' + process.env.PATH,
-        VIRTUAL_ENV: '/workspace/venv'
+        ...process.env
       }
     });
 

--- a/audio-analyzer-frontend/src/app/api/process/route.ts
+++ b/audio-analyzer-frontend/src/app/api/process/route.ts
@@ -187,13 +187,11 @@ function processWithClaude(text: string, prompt: string, apiKey: string, wordLim
       "    print(json.dumps(result))"
     ].join("\\n");
 
-    const python = spawn('/workspace/venv/bin/python', ['-c', pythonScript, text, prompt, apiKey, wordLimit.toString(), outputFormat], {
+    const python = spawn('/usr/bin/python3', ['-c', pythonScript, text, prompt, apiKey, wordLimit.toString(), outputFormat], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: '/workspace',
       env: {
-        ...process.env,
-        PATH: '/workspace/venv/bin:' + process.env.PATH,
-        VIRTUAL_ENV: '/workspace/venv'
+        ...process.env
       }
     });
 

--- a/audio-analyzer-frontend/src/app/api/transcribe/route.ts
+++ b/audio-analyzer-frontend/src/app/api/transcribe/route.ts
@@ -110,13 +110,11 @@ if __name__ == "__main__":
     print(json.dumps(result))
 `;
 
-    const python = spawn('/workspace/venv/bin/python', ['-c', pythonScript, audioPath, model], {
+    const python = spawn('/usr/bin/python3', ['-c', pythonScript, audioPath, model], {
       stdio: ['pipe', 'pipe', 'pipe'],
       cwd: '/workspace',
       env: {
-        ...process.env,
-        PATH: '/workspace/venv/bin:' + process.env.PATH,
-        VIRTUAL_ENV: '/workspace/venv'
+        ...process.env
       }
     });
 


### PR DESCRIPTION
Update Python executable path to `/usr/bin/python3` and remove virtual environment variables to fix model loading errors.

The previous Python path `/workspace/venv/bin/python` caused "ENOENT" errors because the virtual environment did not exist. This change directs the application to use the available system `python3` and removes obsolete virtual environment settings.

---
<a href="https://cursor.com/background-agent?bcId=bc-d43c4e3e-fb22-4b9b-919d-712c2f304ec6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d43c4e3e-fb22-4b9b-919d-712c2f304ec6">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

